### PR TITLE
add DoD to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Repository of the CorreAid project `paris-bikes` for the City of Paris.
 
+TODO project description
+
+TODO project goals
+
+TODO add links to mural, correlaid, etc.
+
+TODO stakeholder list
+
 ## Definition of Done
 
 How do we know that we're really done with a task and have not forgotten anything important? In this project, we use the following Definition of Done:


### PR DESCRIPTION
Add definition of done to readme, as suggested in the startup mural. 

There are a few things to be defined in the future:

- do we want unit tests?
- if so, what should be the minimum coverage?
- which coding standards will we use?

In future we could think of splitting the contents of the readme (project goal, stakeholders, how to run, etc.) from what is usually placed in a `CONTRIBUTING.md` (definition of done, coding standards, info on unit tests, etc.)